### PR TITLE
sd_bus_get_timeout: fix timeout value doc

### DIFF
--- a/man/sd_bus_get_fd.xml
+++ b/man/sd_bus_get_fd.xml
@@ -74,9 +74,10 @@
     without any applied timeout. Note that the returned timeout should be considered only a
     maximum sleeping time. It is permissible (and even expected) that shorter timeouts are used by
     the calling program, in case other event sources are polled in the same event loop. Note that
-    the returned time-value is relative and specified in microseconds. When converting this value in
-    order to pass it as third argument to <function>poll()</function> (which expects milliseconds),
-    care should be taken to use a division that rounds up to ensure the I/O polling operation
+    the returned time-value is absolute, based of <constant>CLOCK_MONOTONIC</constant> and specified 
+    in microseconds. When converting this value in order to pass it as third argument to 
+    <function>poll()</function> (which expects relative milliseconds), care should be taken to convert
+    to a relative time and use a division that rounds up to ensure the I/O polling operation
     doesn't sleep for shorter than necessary, which might result in unintended busy looping
     (alternatively, use
     <citerefentry project='man-pages'><refentrytitle>ppoll</refentrytitle><manvolnum>2</manvolnum></citerefentry>


### PR DESCRIPTION
The documentation of sd_bus_get_timeout wrongfully states that the returned time-value is relative. 
In fact, it is an **absolute** value which is based of **_CLOCK_MONOTONIC_**. This change corrects that part of the documentation.